### PR TITLE
Handle predicates when operand appears more than once; Replace fatalErrors with errors; Support async functions

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,34 +1,33 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "Cryptor",
-        "repositoryURL": "https://github.com/IBM-Swift/BlueCryptor.git",
-        "state": {
-          "branch": null,
-          "revision": "ee5880e031da4c609f372cf7472476ab51d5dd19",
-          "version": "1.0.200"
-        }
-      },
-      {
-        "package": "CryptorECC",
-        "repositoryURL": "https://github.com/IBM-Swift/BlueECC.git",
-        "state": {
-          "branch": null,
-          "revision": "baf6ed3fc1a622675f0041b4aff7c02dd1a93818",
-          "version": "1.2.200"
-        }
-      },
-      {
-        "package": "OpenCombine",
-        "repositoryURL": "https://github.com/OpenCombine/OpenCombine.git",
-        "state": {
-          "branch": null,
-          "revision": "9bba5081344163296ddf537048566b95513b8f39",
-          "version": "0.11.0"
-        }
+  "originHash" : "cdb68b1c15cdf3bfc53a0d73ecd56fd130555e9a0b2e3218897de96fe834deb4",
+  "pins" : [
+    {
+      "identity" : "bluecryptor",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/IBM-Swift/BlueCryptor.git",
+      "state" : {
+        "revision" : "ee5880e031da4c609f372cf7472476ab51d5dd19",
+        "version" : "1.0.200"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "blueecc",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/IBM-Swift/BlueECC.git",
+      "state" : {
+        "revision" : "baf6ed3fc1a622675f0041b4aff7c02dd1a93818",
+        "version" : "1.2.200"
+      }
+    },
+    {
+      "identity" : "opencombine",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/OpenCombine/OpenCombine.git",
+      "state" : {
+        "revision" : "8576f0d579b27020beccbccc3ea6844f3ddfc2c2",
+        "version" : "0.14.0"
+      }
+    }
+  ],
+  "version" : 3
 }

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "cdb68b1c15cdf3bfc53a0d73ecd56fd130555e9a0b2e3218897de96fe834deb4",
+  "originHash" : "3fb997b18c86d15a78d90b91983cde033a9ad87b1c40ab45cdd628d55f5812ed",
   "pins" : [
     {
       "identity" : "bluecryptor",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/IBM-Swift/BlueECC.git",
       "state" : {
-        "revision" : "baf6ed3fc1a622675f0041b4aff7c02dd1a93818",
-        "version" : "1.2.200"
+        "revision" : "1485268a54f8135435a825a855e733f026fa6cc8",
+        "version" : "1.2.201"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.0
+// swift-tools-version:6.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -33,9 +33,9 @@ let package = Package(
         .target(
             name: "CloudyKit",
             dependencies: [
-                "Cryptor",
-                "CryptorECC",
-                "OpenCombine",
+                .product(name: "Cryptor", package: "bluecryptor"),
+                .product(name: "CryptorECC", package: "blueecc"),
+                .product(name: "OpenCombine", package: "OpenCombine"),
                 .product(name: "OpenCombineFoundation", package: "OpenCombine"),
             ]),
         .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.10
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,7 +6,9 @@ import PackageDescription
 let package = Package(
     name: "CloudyKit",
     platforms: [
-        .macOS(.v10_15),
+        .watchOS(.v7),
+        .iOS(.v15),
+        .macOS(.v10_15)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
@@ -16,15 +18,12 @@ let package = Package(
     ],
     dependencies: [
         .package(
-            name: "Cryptor",
             url: "https://github.com/IBM-Swift/BlueCryptor.git",
             from: "1.0.32"),
         .package(
-            name: "CryptorECC",
             url: "https://github.com/IBM-Swift/BlueECC.git",
             from: "1.2.4"),
         .package(
-            name: "OpenCombine",
             url: "https://github.com/OpenCombine/OpenCombine.git",
             from: "0.11.0"),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -25,7 +25,7 @@ let package = Package(
             from: "1.2.4"),
         .package(
             url: "https://github.com/OpenCombine/OpenCombine.git",
-            from: "0.11.0"),
+            from: "0.14.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/CloudyKit/CKDatabase+Async.swift
+++ b/Sources/CloudyKit/CKDatabase+Async.swift
@@ -1,0 +1,56 @@
+//
+//  CKDatabase+Async.swift
+//
+//
+//  Created by Diego Trevisan on 12.12.23.
+//
+
+extension CKDatabase {
+    public func save(_ record: CKRecord) async throws -> CKRecord? {
+        try await withCheckedThrowingContinuation { continuation in
+            save(record) { record, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: record)
+                }
+            }
+        }
+    }
+
+    public func fetch(withRecordID recordID: CKRecord.ID) async throws -> CKRecord? {
+        try await withCheckedThrowingContinuation { continuation in
+            fetch(withRecordID: recordID) { record, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: record)
+                }
+            }
+        }
+    }
+
+    public func delete(withRecordID recordID: CKRecord.ID) async throws -> CKRecord.ID? {
+        try await withCheckedThrowingContinuation { continuation in
+            delete(withRecordID: recordID) { recordID, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: recordID)
+                }
+            }
+        }
+    }
+
+    public func perform(_ query: CKQuery, inZoneWith zoneID: CKRecordZone.ID?) async throws -> [CKRecord]? {
+        try await withCheckedThrowingContinuation { continuation in
+            perform(query, inZoneWith: zoneID) { records, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: records)
+                }
+            }
+        }
+    }
+}

--- a/Sources/CloudyKit/CKError.swift
+++ b/Sources/CloudyKit/CKError.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct CKError: Error {
+public struct CKError: Error, @unchecked Sendable {
     public enum Code: Int {
         case internalError = 1
         case unknownItem = 11

--- a/Sources/CloudyKit/CKQuery.swift
+++ b/Sources/CloudyKit/CKQuery.swift
@@ -35,3 +35,6 @@ public class CKQuery {
     }
     
 }
+
+extension CKSortDescriptor: @unchecked Sendable {}
+extension CKQuery: @unchecked Sendable {}

--- a/Sources/CloudyKit/CKRecord.swift
+++ b/Sources/CloudyKit/CKRecord.swift
@@ -105,3 +105,7 @@ extension CKRecord.ID: CustomStringConvertible {
         
     }
 }
+
+extension CKRecord: @unchecked Sendable {}
+extension CKRecord.ID: @unchecked Sendable {}
+extension CKRecord.Reference: @unchecked Sendable {}

--- a/Sources/CloudyKit/CKRecordZone.swift
+++ b/Sources/CloudyKit/CKRecordZone.swift
@@ -23,3 +23,5 @@ public class CKRecordZone {
     }
     
 }
+
+extension CKRecordZone.ID: @unchecked Sendable {}

--- a/Sources/CloudyKit/CKRequestSignature.swift
+++ b/Sources/CloudyKit/CKRequestSignature.swift
@@ -30,7 +30,7 @@ class CKRequestSignature {
         }
         let hash = dataDigest.final()
         let base64BodyHash = Data(bytes: hash, count: hash.count).base64EncodedString()
-        let signaturePayload = "\(CloudyKitConfig.dateFormatter.string(from: date)):\(base64BodyHash):\(path)"
+        let signaturePayload = "\(CloudyKitConfig.iso8601DateString(from: date)):\(base64BodyHash):\(path)"
         return try signaturePayload.sign(with: self.privateKey.ecPrivateKey).asn1.base64EncodedString()
     }
     

--- a/Sources/CloudyKit/CloudKitWebServices.swift
+++ b/Sources/CloudyKit/CloudKitWebServices.swift
@@ -20,7 +20,7 @@ extension CKWSErrorResponse {
             var userInfo: [String:Any] = [:]
             if reason == "Queried type is not marked indexable" {
                 userInfo[NSLocalizedDescriptionKey] = "Type is not marked indexable"
-            } else if reason.contains("is not marked queryable") && reason.hasPrefix("Field") {
+            } else {
                 userInfo[NSLocalizedDescriptionKey] = reason
             }
             return CKError(code: .invalidArguments, userInfo: userInfo)

--- a/Sources/CloudyKit/CloudyKitConfig.swift
+++ b/Sources/CloudyKit/CloudyKitConfig.swift
@@ -4,21 +4,24 @@ import FoundationNetworking
 #endif
 
 public class CloudyKitConfig {
-    
     public enum Environment: String {
         case development = "development"
         case production = "production"
     }
     
-    public static var environment: Environment = .development
-    public static var serverKeyID: String = "Make sure to update this with your server key."
-    public static var serverPrivateKey: CKPrivateKey? = nil
-    public static var debug = false
+    public nonisolated(unsafe) static var environment: Environment = .development
+    public nonisolated(unsafe) static var serverKeyID: String = "Make sure to update this with your server key."
+    public nonisolated(unsafe) static var serverPrivateKey: CKPrivateKey? = nil
+    public nonisolated(unsafe) static var debug = false
     
-    internal static var urlSession: NetworkSession = URLSession(configuration: .default)
+    internal nonisolated(unsafe) static var urlSession: NetworkSession = URLSession(configuration: .default)
+
     internal static let host = "https://api.apple-cloudkit.com"
-    internal static let dateFormatter = ISO8601DateFormatter()
-    internal static let decoder = JSONDecoder()
-    internal static let encoder = JSONEncoder()
+    internal static var decoder: JSONDecoder { JSONDecoder() }
+    internal static var encoder: JSONEncoder { JSONEncoder() }
+
+    internal static func iso8601DateString(from date: Date) -> String {
+        ISO8601DateFormatter().string(from: date)
+    }
     
 }

--- a/Sources/CloudyKit/Predicate+Helpers.swift
+++ b/Sources/CloudyKit/Predicate+Helpers.swift
@@ -34,6 +34,12 @@ public class CKPredicate {
             if index > 0, arguments.count > 0 {
                 let argument = argumentsLeft.removeFirst()
                 switch argument {
+                case is [String]:
+                    let stringList = argument as? [String] ?? []
+                    let formattedStringList = stringList
+                        .map { "\"\($0)\"" }
+                        .joined(separator: ", ")
+                    substitution += "{ \(formattedStringList) }"
                 case is String:
                     substitution += "\"\(argument)\""
                 case let date as NSDate:

--- a/Sources/CloudyKit/Predicate+Helpers.swift
+++ b/Sources/CloudyKit/Predicate+Helpers.swift
@@ -13,6 +13,10 @@ public typealias Predicate = CKPredicate
 public typealias Predicate = NSPredicate
 #endif
 
+enum CKPredicateError: Error {
+    case invalidPredicate(String)
+}
+
 public class CKPredicate {
     
     public let predicateFormat: String
@@ -58,16 +62,16 @@ public class CKPredicate {
 
 extension Predicate {
     
-    var filterBy: [CKWSFilterDictionary]? {
+    func filterBy() throws -> [CKWSFilterDictionary]? {
         guard self.predicateFormat != "TRUEPREDICATE" else {
             return []
         }
         guard self.predicateFormat != "FALSEPREDICATE" else {
-            fatalError("invalid predicate: \(self.predicateFormat)")
+            throw CKPredicateError.invalidPredicate(self.predicateFormat)
         }
         
         var filters: [CKWSFilterDictionary] = []
-        let (originalComparator, fields) = self.comparatorWithFields()
+        let (originalComparator, fields) = try self.comparatorWithFields()
         var comparator = originalComparator
         var fieldName: String?
         var fieldValue: CKWSRecordFieldValue?
@@ -114,92 +118,92 @@ extension Predicate {
         }
         
         guard let fv = fieldValue, let fn = fieldName else {
-            fatalError("invalid predicate: \(self.predicateFormat)")
+            throw CKPredicateError.invalidPredicate(self.predicateFormat)
         }
         filters.append(CKWSFilterDictionary(comparator: comparator, fieldName: fn, fieldValue: fv))
         return filters
     }
     
-    private func comparatorWithFields() -> (CKWSFilterDictionary.Comparator, [String]) {
-        let doubleEqualsSplits = self.predicateFormat.components(separatedBy: "==")
+    private func comparatorWithFields() throws -> (CKWSFilterDictionary.Comparator, [String]) {
+        let doubleEqualsSplits = self.predicateFormat.components(separatedByFirst: "==")
         if doubleEqualsSplits.count == 2 {
             let fields = doubleEqualsSplits.compactMap { String($0).trimmingCharacters(in: .whitespaces) }
             return (.equals, fields)
         }
         
-        let greaterThanOrEqualsSplits = self.predicateFormat.components(separatedBy: ">=")
+        let greaterThanOrEqualsSplits = self.predicateFormat.components(separatedByFirst: ">=")
         if greaterThanOrEqualsSplits.count == 2 {
             let fields = greaterThanOrEqualsSplits.compactMap { String($0).trimmingCharacters(in: .whitespaces) }
             return (.greaterThanOrEquals, fields)
         }
     
-        let equalsOrGreaterThanSplits = self.predicateFormat.components(separatedBy: "=>")
+        let equalsOrGreaterThanSplits = self.predicateFormat.components(separatedByFirst: "=>")
         if equalsOrGreaterThanSplits.count == 2 {
             let fields = equalsOrGreaterThanSplits.compactMap { String($0).trimmingCharacters(in: .whitespaces) }
             return (.greaterThanOrEquals, fields)
         }
         
-        let lessThanOrEqualsSplits = self.predicateFormat.components(separatedBy: "<=")
+        let lessThanOrEqualsSplits = self.predicateFormat.components(separatedByFirst: "<=")
         if lessThanOrEqualsSplits.count == 2 {
             let fields = lessThanOrEqualsSplits.compactMap { String($0).trimmingCharacters(in: .whitespaces) }
             return (.lessThanOrEquals, fields)
         }
         
-        let equalsOrLessThanSplits = self.predicateFormat.components(separatedBy: "=<")
+        let equalsOrLessThanSplits = self.predicateFormat.components(separatedByFirst: "=<")
         if equalsOrLessThanSplits.count == 2 {
             let fields = equalsOrLessThanSplits.compactMap { String($0).trimmingCharacters(in: .whitespaces) }
             return (.lessThanOrEquals, fields)
         }
         
-        let notEquals = self.predicateFormat.components(separatedBy: "!=")
+        let notEquals = self.predicateFormat.components(separatedByFirst: "!=")
         if notEquals.count == 2 {
             let fields = notEquals.compactMap { String($0).trimmingCharacters(in: .whitespaces) }
             return (.notEquals, fields)
         }
         
-        let 🥕🥕Splits = self.predicateFormat.components(separatedBy: "<>")
+        let 🥕🥕Splits = self.predicateFormat.components(separatedByFirst: "<>")
         if 🥕🥕Splits.count == 2 {
             let fields = 🥕🥕Splits.compactMap { String($0).trimmingCharacters(in: .whitespaces) }
             return (.notEquals, fields)
         }
         
-        let equalsSplits = self.predicateFormat.components(separatedBy: "=")
+        let equalsSplits = self.predicateFormat.components(separatedByFirst: "=")
         if equalsSplits.count == 2 {
            let fields = equalsSplits.compactMap { String($0).trimmingCharacters(in: .whitespaces) }
            return (.equals, fields)
         }
         
-        let greaterThanSplits = self.predicateFormat.components(separatedBy: ">")
+        let greaterThanSplits = self.predicateFormat.components(separatedByFirst: ">")
         if greaterThanSplits.count == 2 {
            let fields = greaterThanSplits.compactMap { String($0).trimmingCharacters(in: .whitespaces) }
            return (.greaterThan, fields)
         }
         
-        let lessThanSplits = self.predicateFormat.components(separatedBy: "<")
+        let lessThanSplits = self.predicateFormat.components(separatedByFirst: "<")
         if lessThanSplits.count == 2 {
            let fields = lessThanSplits.compactMap { String($0).trimmingCharacters(in: .whitespaces) }
            return (.lessThan, fields)
         }
         
-        let containsSplits = self.predicateFormat.components(separatedBy: "CONTAINS")
+        let containsSplits = self.predicateFormat.components(separatedByFirst: "CONTAINS")
         if containsSplits.count == 2 {
            let fields = containsSplits.compactMap { String($0).trimmingCharacters(in: .whitespaces) }
            return (.listContains, fields)
         }
         
-        let beginsWithSplits = self.predicateFormat.components(separatedBy: "BEGINSWITH")
+        let beginsWithSplits = self.predicateFormat.components(separatedByFirst: "BEGINSWITH")
         if beginsWithSplits.count == 2 {
            let fields = beginsWithSplits.compactMap { String($0).trimmingCharacters(in: .whitespaces) }
            return (.beginsWith, fields)
         }
         
-        let inSplits = self.predicateFormat.components(separatedBy: "IN")
+        let inSplits = self.predicateFormat.components(separatedByFirst: "IN")
         if inSplits.count == 2 {
             let fields = inSplits.compactMap { String($0).trimmingCharacters(in: .whitespaces) }
             return (.in, fields)
         }
-        
-        fatalError("invalid predicate: \(self.predicateFormat)")
+
+        throw CKPredicateError.invalidPredicate(self.predicateFormat)
     }
     
 }

--- a/Sources/CloudyKit/String+Components.swift
+++ b/Sources/CloudyKit/String+Components.swift
@@ -1,0 +1,26 @@
+//
+//  String+Components.swift
+//
+//
+//  Created by Diego Trevisan on 11.12.23.
+//
+
+import Foundation
+
+public extension String {
+    func components(separatedByFirst separator: String) -> [String] {
+        guard let range = self.range(of: separator) else {
+            return [self]
+        }
+
+        let firstSegment = self[..<range.lowerBound]
+            .trimmingCharacters(in: .whitespaces)
+        let secondSegment = self[range.upperBound...]
+            .trimmingCharacters(in: .whitespaces)
+
+        return [
+            String(firstSegment),
+            String(secondSegment)
+        ]
+    }
+}

--- a/Sources/CloudyKit/URLSession+Helpers.swift
+++ b/Sources/CloudyKit/URLSession+Helpers.swift
@@ -19,7 +19,7 @@ enum NetworkSessionError: Error {
 }
 
 internal protocol NetworkSession {
-    func internalDataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> NetworkSessionDataTask
+    func internalDataTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> NetworkSessionDataTask
     func internalDataTaskPublisher(for request: URLRequest) -> AnyPublisher<(data: Data, response: URLResponse), Error>
 }
 
@@ -28,7 +28,7 @@ internal protocol NetworkSessionDataTask {
 }
 
 extension URLSession: NetworkSession {
-    func internalDataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> NetworkSessionDataTask {
+    func internalDataTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> NetworkSessionDataTask {
         return self.dataTask(with: request, completionHandler: completionHandler)
     }
     
@@ -109,7 +109,7 @@ extension NetworkSession {
         request.httpMethod = "POST"
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
         request.addValue(CloudyKitConfig.serverKeyID, forHTTPHeaderField: "X-Apple-CloudKit-Request-KeyID")
-        request.addValue(CloudyKitConfig.dateFormatter.string(from: now), forHTTPHeaderField: "X-Apple-CloudKit-Request-ISO8601Date")
+        request.addValue(CloudyKitConfig.iso8601DateString(from: now), forHTTPHeaderField: "X-Apple-CloudKit-Request-ISO8601Date")
         
         var fields: [String:CKWSRecordFieldValue] = [:]
         for (fieldName, value) in record.fields {
@@ -182,7 +182,7 @@ extension NetworkSession {
         request.httpMethod = "POST"
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
         request.addValue(CloudyKitConfig.serverKeyID, forHTTPHeaderField: "X-Apple-CloudKit-Request-KeyID")
-        request.addValue(CloudyKitConfig.dateFormatter.string(from: now), forHTTPHeaderField: "X-Apple-CloudKit-Request-ISO8601Date")
+        request.addValue(CloudyKitConfig.iso8601DateString(from: now), forHTTPHeaderField: "X-Apple-CloudKit-Request-ISO8601Date")
         let records = [
             CKWSLookupRecordDictionary(recordName: recordID.recordName)
         ]
@@ -205,7 +205,7 @@ extension NetworkSession {
             request.httpMethod = "POST"
             request.addValue("application/json", forHTTPHeaderField: "Content-Type")
             request.addValue(CloudyKitConfig.serverKeyID, forHTTPHeaderField: "X-Apple-CloudKit-Request-KeyID")
-            request.addValue(CloudyKitConfig.dateFormatter.string(from: now), forHTTPHeaderField: "X-Apple-CloudKit-Request-ISO8601Date")
+            request.addValue(CloudyKitConfig.iso8601DateString(from: now), forHTTPHeaderField: "X-Apple-CloudKit-Request-ISO8601Date")
             var zoneIDDict: CKWSZoneIDDictionary? = nil
             if let zoneID = zoneID {
                 zoneIDDict = CKWSZoneIDDictionary(zoneName: zoneID.zoneName, ownerName: zoneID.ownerName)
@@ -235,7 +235,7 @@ extension NetworkSession {
         request.httpMethod = "POST"
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
         request.addValue(CloudyKitConfig.serverKeyID, forHTTPHeaderField: "X-Apple-CloudKit-Request-KeyID")
-        request.addValue(CloudyKitConfig.dateFormatter.string(from: now), forHTTPHeaderField: "X-Apple-CloudKit-Request-ISO8601Date")
+        request.addValue(CloudyKitConfig.iso8601DateString(from: now), forHTTPHeaderField: "X-Apple-CloudKit-Request-ISO8601Date")
         let recordDictionary = CKWSRecordDictionary(recordName: recordID.recordName,
                                                     recordType: nil,
                                                     recordChangeTag: nil,
@@ -267,7 +267,7 @@ extension NetworkSession {
         request.httpMethod = "POST"
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
         request.addValue(CloudyKitConfig.serverKeyID, forHTTPHeaderField: "X-Apple-CloudKit-Request-KeyID")
-        request.addValue(CloudyKitConfig.dateFormatter.string(from: now), forHTTPHeaderField: "X-Apple-CloudKit-Request-ISO8601Date")
+        request.addValue(CloudyKitConfig.iso8601DateString(from: now), forHTTPHeaderField: "X-Apple-CloudKit-Request-ISO8601Date")
         if let data = try? CloudyKitConfig.encoder.encode(tokenRequest), let privateKey = CloudyKitConfig.serverPrivateKey {
             let signature = CKRequestSignature(data: data, date: now, path: path, privateKey: privateKey)
             if let signatureValue = try? signature.sign() {

--- a/Tests/CloudyKitTests/Assets.swift
+++ b/Tests/CloudyKitTests/Assets.swift
@@ -10,13 +10,27 @@ import Foundation
 extension Data {
     
     static func loadAsset(name: String) throws -> Data {
-        let path = #file.replacingOccurrences(of: "/Assets.swift", with: "/Assets/") + name
-        return try Data(contentsOf: URL(fileURLWithPath: path))
+        guard let fileURL = assetURL(name: name) else {
+            throw NSError(
+                domain: "CloudyKitTests",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "unable to locate asset named \(name)"]
+            )
+        }
+        return try Data(contentsOf: fileURL)
     }
     
 }
 
 func assetURL(name: String) -> URL? {
-    let path = #file.replacingOccurrences(of: "/Assets.swift", with: "/Assets/") + name
-    return URL(fileURLWithPath: path)
+    let nsName = name as NSString
+    let resource = nsName.deletingPathExtension
+    let ext = nsName.pathExtension.isEmpty ? nil : nsName.pathExtension
+    if let url = Bundle.module.url(forResource: resource, withExtension: ext, subdirectory: "Assets") {
+        return url
+    }
+    if let url = Bundle.module.url(forResource: resource, withExtension: ext) {
+        return url
+    }
+    return nil
 }

--- a/Tests/CloudyKitTests/CKAssetTests.swift
+++ b/Tests/CloudyKitTests/CKAssetTests.swift
@@ -20,7 +20,7 @@ final class CKAssetTests: XCTestCase {
         XCTAssertNotEqual(fileURL, asset.fileURL)
     }
 
-    static var allTests = [
+    static let allTests = [
         ("testInit", testInit),
     ]
 }

--- a/Tests/CloudyKitTests/CKContainerTests.swift
+++ b/Tests/CloudyKitTests/CKContainerTests.swift
@@ -16,7 +16,7 @@ final class CKContainerTests: XCTestCase {
         XCTAssertEqual(CKDatabase.Scope.public, container.publicDatabase.databaseScope)
     }
 
-    static var allTests = [
+    static let allTests = [
         ("testInit", testInit),
     ]
 }

--- a/Tests/CloudyKitTests/CKDatabaseTests.swift
+++ b/Tests/CloudyKitTests/CKDatabaseTests.swift
@@ -785,7 +785,7 @@ final class CKDatabaseTests: XCTestCase {
         self.wait(for: [expectation], timeout: 1)
     }
 
-    static var allTests = [
+    static let allTests = [
         ("testSaveNewRecord", testSaveNewRecord),
         ("testFetchRecord", testFetchRecord),
         ("testQueryRecords", testQueryRecords),

--- a/Tests/CloudyKitTests/CKRecordTests.swift
+++ b/Tests/CloudyKitTests/CKRecordTests.swift
@@ -15,7 +15,7 @@ final class CKRecordTests: XCTestCase {
         XCTAssertEqual("Users", record.recordType)
     }
 
-    static var allTests = [
+    static let allTests = [
         ("testInit", testInit),
     ]
 }

--- a/Tests/CloudyKitTests/Predicate+HelpersTests.swift
+++ b/Tests/CloudyKitTests/Predicate+HelpersTests.swift
@@ -13,7 +13,7 @@ import FoundationNetworking
 
 final class PredicatePlusHelpersTests: XCTestCase {
     
-    func testFieldContainsSpecificValue() {
+    func testFieldContainsSpecificValue() throws {
         let predicates = [
             Predicate(format: "ANY favoriteColors = 'red'"),
             Predicate(format: "favoriteColors CONTAINS 'red'"),
@@ -24,28 +24,28 @@ final class PredicatePlusHelpersTests: XCTestCase {
         for predicate in predicates {
             XCTAssertEqual([
                 CKWSFilterDictionary(comparator: .listContains, fieldName: "favoriteColors", fieldValue: CKWSRecordFieldValue(value: .string("red"), type: nil))
-            ], predicate.filterBy)
+            ], try predicate.filterBy())
         }
     }
     
-    func testMatchFieldToSpecificValue() {
+    func testMatchFieldToSpecificValue() throws {
         let numberPredicate = Predicate(format: "29 = age")
-        XCTAssertEqual([CKWSFilterDictionary(comparator: .equals, fieldName: "age", fieldValue: CKWSRecordFieldValue(value: .number(29), type: nil))], numberPredicate.filterBy)
+        XCTAssertEqual([CKWSFilterDictionary(comparator: .equals, fieldName: "age", fieldValue: CKWSRecordFieldValue(value: .number(29), type: nil))], try numberPredicate.filterBy())
         
         let date = NSDate(timeIntervalSince1970: 123456789)
         let datePredicate = Predicate(format: "today == %@", date)
-        XCTAssertEqual([CKWSFilterDictionary(comparator: .equals, fieldName: "today", fieldValue: CKWSRecordFieldValue(value: .dateTime(Int(date.timeIntervalSince1970 * 1000)), type: nil))], datePredicate.filterBy)
+        XCTAssertEqual([CKWSFilterDictionary(comparator: .equals, fieldName: "today", fieldValue: CKWSRecordFieldValue(value: .dateTime(Int(date.timeIntervalSince1970 * 1000)), type: nil))], try datePredicate.filterBy())
         
         let stringPredicate = Predicate(format: "'red' = favoriteColor")
-        XCTAssertEqual([CKWSFilterDictionary(comparator: .equals, fieldName: "favoriteColor", fieldValue: CKWSRecordFieldValue(value: .string("red"), type: nil))], stringPredicate.filterBy)
+        XCTAssertEqual([CKWSFilterDictionary(comparator: .equals, fieldName: "favoriteColor", fieldValue: CKWSRecordFieldValue(value: .string("red"), type: nil))], try stringPredicate.filterBy())
 
         let recordID = CKRecord.ID(recordName: UUID().uuidString)
         let reference = CKRecord.Reference(recordID: recordID, action: .none)
         let referencePredicate = Predicate(format: "employee == %@", reference)
-        XCTAssertEqual([CKWSFilterDictionary(comparator: .equals, fieldName: "employee", fieldValue: CKWSRecordFieldValue(value: .reference(CKWSReferenceDictionary(recordName: recordID.recordName, action: "NONE")), type: nil))], referencePredicate.filterBy)
+        XCTAssertEqual([CKWSFilterDictionary(comparator: .equals, fieldName: "employee", fieldValue: CKWSRecordFieldValue(value: .reference(CKWSReferenceDictionary(recordName: recordID.recordName, action: "NONE")), type: nil))], try referencePredicate.filterBy())
     }
     
-    func testMatchFieldToOneOrMoreValues() {
+    func testMatchFieldToOneOrMoreValues() throws {
         let predicates = [
             Predicate(format: "ANY { 'red', 'green' } = favoriteColor"),
             Predicate(format: "favoriteColor IN { 'red', 'green' }"),
@@ -54,11 +54,11 @@ final class PredicatePlusHelpersTests: XCTestCase {
         for predicate in predicates {
             XCTAssertEqual([
                 CKWSFilterDictionary(comparator: .in, fieldName: "favoriteColor", fieldValue: CKWSRecordFieldValue(value: .stringList(["red", "green"]), type: nil))
-            ], predicate.filterBy)
+            ], try predicate.filterBy())
         }
     }
     
-    func testMatchFieldThatStartsWithStringValue() {
+    func testMatchFieldThatStartsWithStringValue() throws {
         let predicates = [
             Predicate(format: "ANY favoriteColors BEGINSWITH 'red'"),
             Predicate(format: "ANY favoriteColors BEGINSWITH %@", "red"),
@@ -67,11 +67,11 @@ final class PredicatePlusHelpersTests: XCTestCase {
         for predicate in predicates {
             XCTAssertEqual([
                 CKWSFilterDictionary(comparator: .beginsWith, fieldName: "favoriteColors", fieldValue: CKWSRecordFieldValue(value: .string("red"), type: nil))
-            ], predicate.filterBy)
+            ], try predicate.filterBy())
         }
     }
     
-    func testEqualsComparator() {
+    func testEqualsComparator() throws {
         let predicates = [
             Predicate(format: "number = 13"),
             Predicate(format: "number == 13"),
@@ -79,11 +79,11 @@ final class PredicatePlusHelpersTests: XCTestCase {
         for predicate in predicates {
             XCTAssertEqual([
                 CKWSFilterDictionary(comparator: .equals, fieldName: "number", fieldValue: CKWSRecordFieldValue(value: .number(13), type: nil))
-            ], predicate.filterBy)
+            ], try predicate.filterBy())
         }
     }
     
-    func testGreaterThanOrEqualsComparator() {
+    func testGreaterThanOrEqualsComparator() throws {
         let predicates = [
             Predicate(format: "number >= 13"),
             Predicate(format: "number => 13"),
@@ -91,11 +91,11 @@ final class PredicatePlusHelpersTests: XCTestCase {
         for predicate in predicates {
             XCTAssertEqual([
                 CKWSFilterDictionary(comparator: .greaterThanOrEquals, fieldName: "number", fieldValue: CKWSRecordFieldValue(value: .number(13), type: nil))
-            ], predicate.filterBy)
+            ], try predicate.filterBy())
         }
     }
     
-    func testLessThanOrEqualsComparator() {
+    func testLessThanOrEqualsComparator() throws {
         let predicates = [
             Predicate(format: "number <= 13"),
             Predicate(format: "number =< 13"),
@@ -103,25 +103,25 @@ final class PredicatePlusHelpersTests: XCTestCase {
         for predicate in predicates {
             XCTAssertEqual([
                 CKWSFilterDictionary(comparator: .lessThanOrEquals, fieldName: "number", fieldValue: CKWSRecordFieldValue(value: .number(13), type: nil))
-            ], predicate.filterBy)
+            ], try predicate.filterBy())
         }
     }
     
-    func testGreaterThanComparator() {
+    func testGreaterThanComparator() throws {
         let predicate = Predicate(format: "number > 13")
         XCTAssertEqual([
             CKWSFilterDictionary(comparator: .greaterThan, fieldName: "number", fieldValue: CKWSRecordFieldValue(value: .number(13), type: nil))
-        ], predicate.filterBy)
+        ], try predicate.filterBy())
     }
     
     func testLessThanComparator() {
         let predicate = Predicate(format: "number < 13")
         XCTAssertEqual([
             CKWSFilterDictionary(comparator: .lessThan, fieldName: "number", fieldValue: CKWSRecordFieldValue(value: .number(13), type: nil))
-        ], predicate.filterBy)
+        ], try predicate.filterBy())
     }
     
-    func testNotEqualsComparator() {
+    func testNotEqualsComparator() throws {
         let predicates = [
             Predicate(format: "number != 13"),
             Predicate(format: "number <> 13"),
@@ -129,13 +129,13 @@ final class PredicatePlusHelpersTests: XCTestCase {
         for predicate in predicates {
             XCTAssertEqual([
                 CKWSFilterDictionary(comparator: .notEquals, fieldName: "number", fieldValue: CKWSRecordFieldValue(value: .number(13), type: nil))
-            ], predicate.filterBy)
+            ], try predicate.filterBy())
         }
     }
     
-    func testValuePredicates() {
+    func testValuePredicates() throws {
         let truePredicate = Predicate(value: true)
-        XCTAssertEqual([], truePredicate.filterBy)
+        XCTAssertEqual([], try truePredicate.filterBy())
     }
     
     static var allTests = [

--- a/Tests/CloudyKitTests/Predicate+HelpersTests.swift
+++ b/Tests/CloudyKitTests/Predicate+HelpersTests.swift
@@ -138,7 +138,7 @@ final class PredicatePlusHelpersTests: XCTestCase {
         XCTAssertEqual([], try truePredicate.filterBy())
     }
     
-    static var allTests = [
+    static let allTests = [
         ("testFieldContainsSpecificValue", testFieldContainsSpecificValue),
         ("testMatchFieldToSpecificValue", testMatchFieldToSpecificValue),
         ("testMatchFieldToOneOrMoreValues", testMatchFieldToOneOrMoreValues),

--- a/Tests/CloudyKitTests/String+ComponentsTests.swift
+++ b/Tests/CloudyKitTests/String+ComponentsTests.swift
@@ -1,0 +1,44 @@
+//
+//  String+ComponentsTests.swift
+//  
+//
+//  Created by Diego Trevisan on 11.12.23.
+//
+
+import XCTest
+import CloudyKit
+
+final class StringTests: XCTestCase {
+    
+    func testSeparationWhenOneOccurrence() {
+        var segments = "name IN {'Camden', 'Diego'}"
+            .components(separatedByFirst: "IN")
+
+        XCTAssertEqual(segments.count, 2)
+        XCTAssertEqual(segments[0], "name")
+        XCTAssertEqual(segments[1], "{'Camden', 'Diego'}")
+    }
+
+    func testSeparationWhenMultipleOccurrences() {
+        var segments = "app IN {'INSTAGRAM'}"
+            .components(separatedByFirst: "IN")
+
+        XCTAssertEqual(segments.count, 2)
+        XCTAssertEqual(segments[0], "app")
+        XCTAssertEqual(segments[1], "{'INSTAGRAM'}")
+    }
+
+    func testSeparationWhenNoOccurrences() {
+        var segments = "something == foo"
+            .components(separatedByFirst: "IN")
+
+        XCTAssertEqual(segments.count, 1)
+        XCTAssertEqual(segments[0], "something == foo")
+    }
+
+    static var allTests = [
+        ("testSeparationWhenOneOccurrence", testSeparationWhenOneOccurrence),
+        ("testSeparationWhenMultipleOccurrences", testSeparationWhenMultipleOccurrences),
+        ("testSeparationWhenNoOccurrences", testSeparationWhenNoOccurrences)
+    ]
+}

--- a/Tests/CloudyKitTests/String+ComponentsTests.swift
+++ b/Tests/CloudyKitTests/String+ComponentsTests.swift
@@ -11,7 +11,7 @@ import CloudyKit
 final class StringTests: XCTestCase {
     
     func testSeparationWhenOneOccurrence() {
-        var segments = "name IN {'Camden', 'Diego'}"
+        let segments = "name IN {'Camden', 'Diego'}"
             .components(separatedByFirst: "IN")
 
         XCTAssertEqual(segments.count, 2)
@@ -20,7 +20,7 @@ final class StringTests: XCTestCase {
     }
 
     func testSeparationWhenMultipleOccurrences() {
-        var segments = "app IN {'INSTAGRAM'}"
+        let segments = "app IN {'INSTAGRAM'}"
             .components(separatedByFirst: "IN")
 
         XCTAssertEqual(segments.count, 2)
@@ -29,14 +29,14 @@ final class StringTests: XCTestCase {
     }
 
     func testSeparationWhenNoOccurrences() {
-        var segments = "something == foo"
+        let segments = "something == foo"
             .components(separatedByFirst: "IN")
 
         XCTAssertEqual(segments.count, 1)
         XCTAssertEqual(segments[0], "something == foo")
     }
 
-    static var allTests = [
+    static let allTests = [
         ("testSeparationWhenOneOccurrence", testSeparationWhenOneOccurrence),
         ("testSeparationWhenMultipleOccurrences", testSeparationWhenMultipleOccurrences),
         ("testSeparationWhenNoOccurrences", testSeparationWhenNoOccurrences)


### PR DESCRIPTION
So I decided to fix a bug and do some improvements to CloudyKit:

- FIX: Before some predicate like "app IN INSTAGRAM" would crash because number of components separated by "IN" would be different of 2.
- Abolish the fatalErrors and make use of throwable functions
- Support async functions

@camdenfullmer would love if you could take a look, so that I can point my project to your repo instead of my fork :)